### PR TITLE
Add more bindings to the main viewer

### DIFF
--- a/frogmouth/widgets/viewer.py
+++ b/frogmouth/widgets/viewer.py
@@ -107,6 +107,7 @@ class Viewer(VerticalScroll, can_focus=True, can_focus_children=True):
         Binding("w,k", "scroll_up", "", show=False),
         Binding("s,j", "scroll_down", "", show=False),
         Binding("space", "page_down", "", show=False),
+        Binding("b", "page_up", "", show=False),
     ]
     """Bindings for the Markdown viewer widget."""
 

--- a/frogmouth/widgets/viewer.py
+++ b/frogmouth/widgets/viewer.py
@@ -106,7 +106,7 @@ class Viewer(VerticalScroll, can_focus=True, can_focus_children=True):
     BINDINGS = [
         Binding("w,k", "scroll_up", "", show=False),
         Binding("s,j", "scroll_down", "", show=False),
-        Binding("space", "scroll_page_down", "", show=False),
+        Binding("space", "page_down", "", show=False),
     ]
     """Bindings for the Markdown viewer widget."""
 
@@ -295,7 +295,3 @@ class Viewer(VerticalScroll, can_focus=True, can_focus_children=True):
         """
         self.history = History(history)
         self.post_message(self.HistoryUpdated(self))
-
-    def action_scroll_page_down(self) -> None:
-        """Action wrapper for scrolling down."""
-        self.scroll_page_down()


### PR DESCRIPTION
I started adding a couple of bindings to the main viewer pane on `main`, then decided now was the time to lock `main` and start working in branches and PRing, so...

This isn't too much of a change really, just adding the the keystrokes some folk might think to tap when leaning back in their comfy terminal and idling their way through a document. Borrowing from `less` a little here.