### PR TITLE
Move the input dialogs over to the newer `Screen` result approach

### DIFF
--- a/frogmouth/dialogs/__init__.py
+++ b/frogmouth/dialogs/__init__.py
@@ -3,14 +3,13 @@
 from .error import ErrorDialog
 from .help_dialog import HelpDialog
 from .information import InformationDialog
-from .input_dialog import InputDialog, InputDialogResult
+from .input_dialog import InputDialog
 from .yes_no_dialog import YesNoDialog
 
 __all__ = [
     "ErrorDialog",
     "InformationDialog",
     "InputDialog",
-    "InputDialogResult",
     "HelpDialog",
     "YesNoDialog",
 ]

--- a/frogmouth/dialogs/__init__.py
+++ b/frogmouth/dialogs/__init__.py
@@ -3,13 +3,14 @@
 from .error import ErrorDialog
 from .help_dialog import HelpDialog
 from .information import InformationDialog
-from .input_dialog import InputDialog
+from .input_dialog import InputDialog, InputDialogResult
 from .yes_no_dialog import YesNoDialog
 
 __all__ = [
     "ErrorDialog",
     "InformationDialog",
     "InputDialog",
+    "InputDialogResult",
     "HelpDialog",
     "YesNoDialog",
 ]

--- a/frogmouth/dialogs/input_dialog.py
+++ b/frogmouth/dialogs/input_dialog.py
@@ -6,7 +6,6 @@ from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical
 from textual.screen import ModalScreen
-from textual.widget import Widget
 from textual.widgets import Button, Input, Label
 
 
@@ -56,25 +55,14 @@ class InputDialog(ModalScreen[str]):
     ]
     """Bindings for the dialog."""
 
-    def __init__(  # pylint:disable=redefined-builtin
-        self,
-        requester: Widget,
-        prompt: str,
-        initial: str | None = None,
-        id: str | None = None,
-    ) -> None:
+    def __init__(self, prompt: str, initial: str | None = None) -> None:
         """Initialise the input dialog.
 
         Args:
-            requester: The widget requesting the input.
             prompt: The prompt for the input.
             initial: The initial value for the input.
-            cargo: Any cargo value for the input.
-            id: The ID for the dialog.
         """
-        super().__init__(id=id)
-        self._requester = requester
-        """A reference to the widget requesting the input."""
+        super().__init__()
         self._prompt = prompt
         """The prompt to display for the input."""
         self._initial = initial

--- a/frogmouth/dialogs/input_dialog.py
+++ b/frogmouth/dialogs/input_dialog.py
@@ -12,17 +12,7 @@ from textual.widget import Widget
 from textual.widgets import Button, Input, Label
 
 
-class InputDialogResult(NamedTuple):
-    """The result of input with an `InputDialog`."""
-
-    dialog_id: str | None
-    """The ID of the dialog returning the result."""
-
-    value: str
-    """The input value."""
-
-
-class InputDialog(ModalScreen[InputDialogResult]):
+class InputDialog(ModalScreen[str]):
     """A modal dialog for getting a single input from the user."""
 
     DEFAULT_CSS = """
@@ -115,7 +105,7 @@ class InputDialog(ModalScreen[InputDialogResult]):
         if event.button.id == "cancel":
             self.app.pop_screen()
         elif event.button.id == "ok" and self.query_one(Input).value.strip():
-            self.dismiss(InputDialogResult(self.id, self.query_one(Input).value))
+            self.dismiss(self.query_one(Input).value)
 
     def on_input_submitted(self) -> None:
         """Do default processing when the user hits enter in the input."""

--- a/frogmouth/dialogs/input_dialog.py
+++ b/frogmouth/dialogs/input_dialog.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import NamedTuple
-
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical

--- a/frogmouth/dialogs/yes_no_dialog.py
+++ b/frogmouth/dialogs/yes_no_dialog.py
@@ -2,13 +2,10 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Center, Horizontal, Vertical
 from textual.screen import ModalScreen
-from textual.widget import Widget
 from textual.widgets import Button, Static
 
 
@@ -65,16 +62,13 @@ class YesNoDialog(ModalScreen[bool]):
     ]
     """Bindings for the yes/no dialog."""
 
-    def __init__(  # pylint:disable=redefined-builtin,too-many-arguments
+    def __init__(  # pylint:disable=too-many-arguments
         self,
-        requester: Widget,
         title: str,
         question: str,
         yes_label: str = "Yes",
         no_label: str = "No",
         yes_first: bool = True,
-        cargo: Any = None,
-        id: str | None = None,
     ) -> None:
         """Initialise the yes/no dialog.
 
@@ -88,9 +82,7 @@ class YesNoDialog(ModalScreen[bool]):
             cargo: Any cargo value for the question.
             id: The ID for the dialog.
         """
-        super().__init__(id=id)
-        self._requester = requester
-        """A reference to the widget asking the question."""
+        super().__init__()
         self._title = title
         """The title for the dialog."""
         self._question = question
@@ -101,8 +93,6 @@ class YesNoDialog(ModalScreen[bool]):
         """The label for the no button."""
         self._aye_first = yes_first
         """Should the positive button come first?"""
-        self._cargo = cargo
-        """Any cargo data for the reply."""
 
     def compose(self) -> ComposeResult:
         """Compose the content of the dialog."""

--- a/frogmouth/dialogs/yes_no_dialog.py
+++ b/frogmouth/dialogs/yes_no_dialog.py
@@ -7,13 +7,12 @@ from typing import Any
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Center, Horizontal, Vertical
-from textual.message import Message
 from textual.screen import ModalScreen
 from textual.widget import Widget
 from textual.widgets import Button, Static
 
 
-class YesNoDialog(ModalScreen[None]):
+class YesNoDialog(ModalScreen[bool]):
     """A dialog for asking a user a yes/no question."""
 
     DEFAULT_CSS = """
@@ -127,37 +126,10 @@ class YesNoDialog(ModalScreen[None]):
         """Configure the dialog once the DOM is ready."""
         self.query(Button).first().focus()
 
-    class Reply(Message):
-        """Base class for replies from the yes/no dialog."""
-
-        def __init__(self, sender_id: str | None, cargo: Any = None) -> None:
-            """Initialise the reply message.
-
-            Args:
-                sender_id: The ID of the dialog sending the message.
-                cargo: Any cargo data for the result.
-            """
-            super().__init__()
-            self.sender_id: str | None = sender_id
-            """The ID of the sending dialog."""
-            self.cargo: Any = cargo
-            """Cargo data for the result."""
-
-    class PositiveReply(Reply):
-        """A positive reply from the yes/no dialog."""
-
-    class NegativeReply(Reply):
-        """A negative reply from the yes/no dialog."""
-
     def on_button_pressed(self, event: Button.Pressed) -> None:
         """Handle a button being pressed on the dialog.
 
         Args:
             event: The event to handle.
         """
-        self._requester.post_message(
-            (self.PositiveReply if event.button.id == "yes" else self.NegativeReply)(
-                self.id, self._cargo
-            )
-        )
-        self.app.pop_screen()
+        self.dismiss(event.button.id == "yes")

--- a/frogmouth/screens/main.py
+++ b/frogmouth/screens/main.py
@@ -503,7 +503,7 @@ class Main(Screen[None]):  # pylint:disable=too-many-public-methods
 
         # Give the user a chance to edit the title.
         self.app.push_screen(
-            InputDialog(self, "Bookmark title:", title),
+            InputDialog("Bookmark title:", title),
             partial(self.add_bookmark, location),
         )
 

--- a/frogmouth/screens/main.py
+++ b/frogmouth/screens/main.py
@@ -17,13 +17,7 @@ from textual.widgets import Footer, Markdown
 
 from .. import __version__
 from ..data import load_config, load_history, save_config, save_history
-from ..dialogs import (
-    ErrorDialog,
-    HelpDialog,
-    InformationDialog,
-    InputDialog,
-    InputDialogResult,
-)
+from ..dialogs import ErrorDialog, HelpDialog, InformationDialog, InputDialog
 from ..utility import (
     build_raw_bitbucket_url,
     build_raw_github_url,
@@ -478,14 +472,14 @@ class Main(Screen[None]):  # pylint:disable=too-many-public-methods
             )
         )
 
-    def add_bookmark(self, location: Path | URL, bookmark: InputDialogResult) -> None:
+    def add_bookmark(self, location: Path | URL, bookmark: str) -> None:
         """Handle adding the bookmark.
 
         Args:
             location: The location to bookmark.
             bookmark: The bookmark to add.
         """
-        self.query_one(Navigation).bookmarks.add_bookmark(bookmark.value, location)
+        self.query_one(Navigation).bookmarks.add_bookmark(bookmark, location)
 
     def action_bookmark_this(self) -> None:
         """Add a bookmark for the currently-viewed file."""

--- a/frogmouth/widgets/navigation.py
+++ b/frogmouth/widgets/navigation.py
@@ -11,10 +11,10 @@ from textual.reactive import var
 from textual.widgets import TabbedContent, Tabs
 from typing_extensions import Self
 
-from .navigation_panes.navigation_pane import NavigationPane
 from .navigation_panes.bookmarks import Bookmarks
 from .navigation_panes.history import History
 from .navigation_panes.local_files import LocalFiles
+from .navigation_panes.navigation_pane import NavigationPane
 from .navigation_panes.table_of_contents import TableOfContents
 
 

--- a/frogmouth/widgets/navigation_panes/bookmarks.py
+++ b/frogmouth/widgets/navigation_panes/bookmarks.py
@@ -140,10 +140,8 @@ class Bookmarks(NavigationPane):
         if (bookmark := self.query_one(OptionList).highlighted) is not None:
             self.app.push_screen(
                 YesNoDialog(
-                    self,
                     "Delete bookmark",
                     "Are you sure you want to delete the bookmark?",
-                    id="delete",
                 ),
                 partial(self.delete_bookmark, bookmark),
             )
@@ -165,7 +163,6 @@ class Bookmarks(NavigationPane):
         if (bookmark := self.query_one(OptionList).highlighted) is not None:
             self.app.push_screen(
                 InputDialog(
-                    self,
                     "Bookmark title:",
                     self._bookmarks[bookmark].title,
                 ),

--- a/frogmouth/widgets/navigation_panes/bookmarks.py
+++ b/frogmouth/widgets/navigation_panes/bookmarks.py
@@ -14,7 +14,7 @@ from textual.widgets import OptionList
 from textual.widgets.option_list import Option
 
 from ...data import Bookmark, load_bookmarks, save_bookmarks
-from ...dialogs import InputDialog, InputDialogResult, YesNoDialog
+from ...dialogs import InputDialog, YesNoDialog
 from .navigation_pane import NavigationPane
 
 
@@ -148,7 +148,7 @@ class Bookmarks(NavigationPane):
                 partial(self.delete_bookmark, bookmark),
             )
 
-    def rename_bookmark(self, bookmark: int, new_name: InputDialogResult) -> None:
+    def rename_bookmark(self, bookmark: int, new_name: str) -> None:
         """Rename the current bookmark.
 
         Args:
@@ -156,7 +156,7 @@ class Bookmarks(NavigationPane):
             new_name: The input dialog result that is the new name.
         """
         self._bookmarks[bookmark] = Bookmark(
-            new_name.value, self._bookmarks[bookmark].location
+            new_name, self._bookmarks[bookmark].location
         )
         self._bookmarks_updated()
 

--- a/frogmouth/widgets/navigation_panes/bookmarks.py
+++ b/frogmouth/widgets/navigation_panes/bookmarks.py
@@ -124,28 +124,29 @@ class Bookmarks(NavigationPane):
         assert isinstance(event.option, Entry)
         self.post_message(self.Goto(event.option.bookmark))
 
+    def delete_bookmark(self, bookmark: int, delete_it: bool) -> None:
+        """Delete a given bookmark.
+
+        Args:
+            bookmark: The bookmark to delete.
+            delete_it: Should it be deleted?
+        """
+        if delete_it:
+            del self._bookmarks[bookmark]
+            self._bookmarks_updated()
+
     def action_delete(self) -> None:
         """Delete the highlighted bookmark."""
-        if self.query_one(OptionList).highlighted is not None:
+        if (bookmark := self.query_one(OptionList).highlighted) is not None:
             self.app.push_screen(
                 YesNoDialog(
                     self,
                     "Delete bookmark",
                     "Are you sure you want to delete the bookmark?",
                     id="delete",
-                )
+                ),
+                partial(self.delete_bookmark, bookmark),
             )
-
-    def on_yes_no_dialog_positive_reply(self, event: YesNoDialog.PositiveReply) -> None:
-        """Handle a yes/no dialog giving a positive reply.
-
-        Args:
-            event: The event to handle.
-        """
-        bookmarks = self.query_one(OptionList)
-        if event.sender_id == "delete" and bookmarks.highlighted is not None:
-            del self._bookmarks[bookmarks.highlighted]
-            self._bookmarks_updated()
 
     def rename_bookmark(self, bookmark: int, new_name: InputDialogResult) -> None:
         """Rename the current bookmark.

--- a/frogmouth/widgets/navigation_panes/navigation_pane.py
+++ b/frogmouth/widgets/navigation_panes/navigation_pane.py
@@ -1,9 +1,7 @@
 """Provides a base class for all navigation panes."""
 
-from typing_extensions import Self
-
-
 from textual.widgets import TabbedContent, TabPane
+from typing_extensions import Self
 
 
 class NavigationPane(TabPane):


### PR DESCRIPTION
As outlined in #9, since starting this, and indeed somewhat motivated by the work in here, Textual now has a method of returning results from a screen (best used with `ModalScreen`, although not exclusive to it). Now that this approach is stable in Textual this is a set of changes to move Frogmouth's dialogs over to result-returning rather than message-sending.