### PR TITLE
Update for Textual v0.23.0

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,11 @@
 # Frogmouth ChangeLog
 
+## Unreleased
+
+### Changed
+
+- Updated to work with [Textual](https://github.com/Textualize/textual) v0.23.0.
+
 ## [0.4.0] - 2023-05-03
 
 ### Added

--- a/frogmouth/dialogs/input_dialog.py
+++ b/frogmouth/dialogs/input_dialog.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from textual import on
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical
@@ -82,17 +83,14 @@ class InputDialog(ModalScreen[str]):
         """Set up the dialog once the DOM is ready."""
         self.query_one(Input).focus()
 
-    def on_button_pressed(self, event: Button.Pressed) -> None:
-        """Handle one of the dialog's buttons been pressed.
+    @on(Button.Pressed, "#cancel")
+    def cancel_input(self) -> None:
+        """Cancel the input operation."""
+        self.app.pop_screen()
 
-        Args:
-            event: The button press event.
-        """
-        if event.button.id == "cancel":
-            self.app.pop_screen()
-        elif event.button.id == "ok" and self.query_one(Input).value.strip():
-            self.dismiss(self.query_one(Input).value)
-
-    def on_input_submitted(self) -> None:
-        """Do default processing when the user hits enter in the input."""
-        self.query_one("#ok", Button).press()
+    @on(Input.Submitted)
+    @on(Button.Pressed, "#ok")
+    def accept_input(self) -> None:
+        """Accept and return the input."""
+        if value := self.query_one(Input).value.strip():
+            self.dismiss(value)

--- a/frogmouth/screens/main.py
+++ b/frogmouth/screens/main.py
@@ -207,17 +207,15 @@ class Main(Screen[None]):  # pylint:disable=too-many-public-methods
         """Handle being asked to show the table of contents."""
         self.action_table_of_contents()
 
-    async def on_omnibox_local_files_command(self) -> None:
+    def on_omnibox_local_files_command(self) -> None:
         """Handle being asked to view the local files picker."""
-        await self.action_local_files()
+        self.action_local_files()
 
     def on_omnibox_bookmarks_command(self) -> None:
         """Handle being asked to view the bookmarks."""
         self.action_bookmarks()
 
-    async def on_omnibox_local_chdir_command(
-        self, event: Omnibox.LocalChdirCommand
-    ) -> None:
+    def on_omnibox_local_chdir_command(self, event: Omnibox.LocalChdirCommand) -> None:
         """Handle being asked to view a new directory in the local files picker.
 
         Args:
@@ -232,7 +230,7 @@ class Main(Screen[None]):  # pylint:disable=too-many-public-methods
                 ErrorDialog("Not a directory", f"{event.target} is not a directory.")
             )
         else:
-            await self.query_one(Navigation).jump_to_local_files(event.target)
+            self.query_one(Navigation).jump_to_local_files(event.target)
 
     def on_omnibox_history_command(self) -> None:
         """Handle being asked to view the history."""
@@ -436,9 +434,9 @@ class Main(Screen[None]):  # pylint:disable=too-many-public-methods
         """Display and focus the table of contents pane."""
         self.query_one(Navigation).jump_to_contents()
 
-    async def action_local_files(self) -> None:
+    def action_local_files(self) -> None:
         """Display and focus the local files selection pane."""
-        await self.query_one(Navigation).jump_to_local_files()
+        self.query_one(Navigation).jump_to_local_files()
 
     def action_bookmarks(self) -> None:
         """Display and focus the bookmarks selection pane."""

--- a/frogmouth/widgets/navigation.py
+++ b/frogmouth/widgets/navigation.py
@@ -94,7 +94,7 @@ class Navigation(Vertical, can_focus=False, can_focus_children=True):
         """The history widget."""
         return self._history
 
-    async def jump_to_local_files(self, target: Path | None = None) -> Self:
+    def jump_to_local_files(self, target: Path | None = None) -> Self:
         """Switch to and focus the local files pane.
 
         Returns:
@@ -102,7 +102,7 @@ class Navigation(Vertical, can_focus=False, can_focus_children=True):
         """
         self.popped_out = True
         if target is not None:
-            await self._local_files.chdir(target)
+            self._local_files.chdir(target)
         self._local_files.activate().set_focus_within()
         return self
 

--- a/frogmouth/widgets/navigation_panes/local_files.py
+++ b/frogmouth/widgets/navigation_panes/local_files.py
@@ -67,18 +67,16 @@ class LocalFiles(NavigationPane):
 
     def compose(self) -> ComposeResult:
         """Compose the child widgets."""
-        yield FilteredDirectoryTree(Path("~").expanduser())
+        # TODO: Until https://github.com/Textualize/textual/pull/2473 goes out.
+        yield FilteredDirectoryTree(Path("."))  # Path("~").expanduser())
 
-    async def chdir(self, path: Path) -> None:
-        """Change the filesystem view to the given directory."""
-        # At the moment Textual's DirectoryTree doesn't support changing
-        # directory to a new root, so here we're going to remove it and
-        # mount a fresh one with a new root.
-        #
-        # Once https://github.com/Textualize/textual/issues/2056 is taken
-        # care of update this to use whatever new approach is taken.
-        await self.query_one(FilteredDirectoryTree).remove()
-        await self.mount(FilteredDirectoryTree(path))
+    def chdir(self, path: Path) -> None:
+        """Change the filesystem view to the given directory.
+
+        Args:
+            path: The path to change to.
+        """
+        self.query_one(FilteredDirectoryTree).path = path
 
     def set_focus_within(self) -> None:
         """Focus the directory tree.."""

--- a/frogmouth/widgets/navigation_panes/local_files.py
+++ b/frogmouth/widgets/navigation_panes/local_files.py
@@ -67,8 +67,7 @@ class LocalFiles(NavigationPane):
 
     def compose(self) -> ComposeResult:
         """Compose the child widgets."""
-        # TODO: Until https://github.com/Textualize/textual/pull/2473 goes out.
-        yield FilteredDirectoryTree(Path("."))  # Path("~").expanduser())
+        yield FilteredDirectoryTree(Path("~").expanduser())
 
     def chdir(self, path: Path) -> None:
         """Change the filesystem view to the given directory.

--- a/frogmouth/widgets/navigation_panes/table_of_contents.py
+++ b/frogmouth/widgets/navigation_panes/table_of_contents.py
@@ -2,7 +2,7 @@
 
 from textual.app import ComposeResult
 from textual.widgets import Markdown, Tree
-from textual.widgets.markdown import Markdown, MarkdownTableOfContents
+from textual.widgets.markdown import MarkdownTableOfContents
 
 from .navigation_pane import NavigationPane
 

--- a/frogmouth/widgets/navigation_panes/table_of_contents.py
+++ b/frogmouth/widgets/navigation_panes/table_of_contents.py
@@ -2,7 +2,7 @@
 
 from textual.app import ComposeResult
 from textual.widgets import Markdown, Tree
-from textual.widgets.markdown import MarkdownTableOfContents
+from textual.widgets.markdown import Markdown, MarkdownTableOfContents
 
 from .navigation_pane import NavigationPane
 
@@ -44,7 +44,17 @@ class TableOfContents(NavigationPane):
 
     def compose(self) -> ComposeResult:
         """Compose the child widgets."""
-        yield MarkdownTableOfContents()
+        # Note the use of a throwaway Markdown object. Textual 0.24
+        # introduced a requirement for MarkdownTableOfContents to take a
+        # reference to a Markdown document; this is a problem if you're
+        # composing the ToC in a location somewhere unrelated to the
+        # document itself, such that you can't guarantee the order in which
+        # they're compose. I'm not using the ToC in a way that's
+        # tightly-coupled to the document, neither am I using multiple ToCs
+        # and documents. So... we make one and ignore it.
+        #
+        # I think I'll issue this.
+        yield MarkdownTableOfContents(Markdown())
 
     def on_table_of_contents_updated(
         self, event: Markdown.TableOfContentsUpdated

--- a/frogmouth/widgets/navigation_panes/table_of_contents.py
+++ b/frogmouth/widgets/navigation_panes/table_of_contents.py
@@ -53,7 +53,7 @@ class TableOfContents(NavigationPane):
         # tightly-coupled to the document, neither am I using multiple ToCs
         # and documents. So... we make one and ignore it.
         #
-        # I think I'll issue this.
+        # https://github.com/Textualize/textual/issues/2516
         yield MarkdownTableOfContents(Markdown())
 
     def on_table_of_contents_updated(

--- a/poetry.lock
+++ b/poetry.lock
@@ -198,14 +198,14 @@ tests-no-zope = ["cloudpickle", "hypothesis", "mypy (>=1.1.1)", "pympler", "pyte
 
 [[package]]
 name = "certifi"
-version = "2022.12.7"
+version = "2023.5.7"
 description = "Python package for providing Mozilla's CA Bundle."
 category = "main"
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "certifi-2022.12.7-py3-none-any.whl", hash = "sha256:4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18"},
-    {file = "certifi-2022.12.7.tar.gz", hash = "sha256:35824b4c3a97115964b408844d64aa14db1cc518f6562e8d7261699d1350a9e3"},
+    {file = "certifi-2023.5.7-py3-none-any.whl", hash = "sha256:c6c2e98f5c7869efca1f8916fed228dd91539f9f1b444c314c06eef02980c716"},
+    {file = "certifi-2023.5.7.tar.gz", hash = "sha256:0f0d56dc5a6ad56fd4ba36484d6cc34451e1c6548c61daad8c320169f91eddc7"},
 ]
 
 [[package]]
@@ -1003,14 +1003,14 @@ plugins = ["importlib-metadata"]
 
 [[package]]
 name = "pylint"
-version = "2.17.3"
+version = "2.17.4"
 description = "python code static checker"
 category = "dev"
 optional = false
 python-versions = ">=3.7.2"
 files = [
-    {file = "pylint-2.17.3-py3-none-any.whl", hash = "sha256:a6cbb4c6e96eab4a3c7de7c6383c512478f58f88d95764507d84c899d656a89a"},
-    {file = "pylint-2.17.3.tar.gz", hash = "sha256:761907349e699f8afdcd56c4fe02f3021ab5b3a0fc26d19a9bfdc66c7d0d5cd5"},
+    {file = "pylint-2.17.4-py3-none-any.whl", hash = "sha256:7a1145fb08c251bdb5cca11739722ce64a63db479283d10ce718b2460e54123c"},
+    {file = "pylint-2.17.4.tar.gz", hash = "sha256:5dcf1d9e19f41f38e4e85d10f511e5b9c35e1aa74251bf95cdd8cb23584e2db1"},
 ]
 
 [package.dependencies]
@@ -1150,14 +1150,14 @@ files = [
 
 [[package]]
 name = "textual"
-version = "0.23.0"
+version = "0.24.1"
 description = "Modern Text User Interface framework"
 category = "main"
 optional = false
 python-versions = ">=3.7,<4.0"
 files = [
-    {file = "textual-0.23.0-py3-none-any.whl", hash = "sha256:9eb1284ae312801b12b19668bf84faa2ae226a2ab6269e5f84edff851f2ad371"},
-    {file = "textual-0.23.0.tar.gz", hash = "sha256:f3e08d7afaf6c8562d2d5d6230fa891b515ebf9813cda4ea1807a639032edbd4"},
+    {file = "textual-0.24.1-py3-none-any.whl", hash = "sha256:a7deb7ac5a1502424c754fe165ae13cb3890e47ddc514d3f089cb2984c336d1d"},
+    {file = "textual-0.24.1.tar.gz", hash = "sha256:4c7e1f4ed12b9615c63fa3eb7cb9df68d29e0ae5b2352997958cd7ee5533f926"},
 ]
 
 [package.dependencies]
@@ -1448,4 +1448,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "efcb264d936ddfae97fee65988e4ae4f0d242ce19a7c6dce04ce7a1f8edf6395"
+content-hash = "5876afd4c2ea8f0f3346d6aea2d623ca9a0c48794a9b08de3c481d15cf66e559"

--- a/poetry.lock
+++ b/poetry.lock
@@ -519,14 +519,14 @@ socks = ["socksio (>=1.0.0,<2.0.0)"]
 
 [[package]]
 name = "identify"
-version = "2.5.23"
+version = "2.5.24"
 description = "File identification library for Python"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "identify-2.5.23-py2.py3-none-any.whl", hash = "sha256:17d9351c028a781456965e781ed2a435755cac655df1ebd930f7186b54399312"},
-    {file = "identify-2.5.23.tar.gz", hash = "sha256:50b01b9d5f73c6b53e5fa2caf9f543d3e657a9d0bbdeb203ebb8d45960ba7433"},
+    {file = "identify-2.5.24-py2.py3-none-any.whl", hash = "sha256:986dbfb38b1140e763e413e6feb44cd731faf72d1909543178aa79b0e258265d"},
+    {file = "identify-2.5.24.tar.gz", hash = "sha256:0aac67d5b4812498056d28a9a512a483f5085cc28640b02b258a59dac34301d4"},
 ]
 
 [package.extras]
@@ -630,14 +630,14 @@ files = [
 
 [[package]]
 name = "linkify-it-py"
-version = "2.0.0"
+version = "2.0.2"
 description = "Links recognition library with FULL unicode support."
 category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 files = [
-    {file = "linkify-it-py-2.0.0.tar.gz", hash = "sha256:476464480906bed8b2fa3813bf55566282e55214ad7e41b7d1c2b564666caf2f"},
-    {file = "linkify_it_py-2.0.0-py3-none-any.whl", hash = "sha256:1bff43823e24e507a099e328fc54696124423dd6320c75a9da45b4b754b748ad"},
+    {file = "linkify-it-py-2.0.2.tar.gz", hash = "sha256:19f3060727842c254c808e99d465c80c49d2c7306788140987a1a7a29b0d6ad2"},
+    {file = "linkify_it_py-2.0.2-py3-none-any.whl", hash = "sha256:a3a24428f6c96f27370d7fe61d2ac0be09017be5190d68d8658233171f1b6541"},
 ]
 
 [package.dependencies]
@@ -645,7 +645,7 @@ uc-micro-py = "*"
 
 [package.extras]
 benchmark = ["pytest", "pytest-benchmark"]
-dev = ["black", "flake8", "isort", "pre-commit"]
+dev = ["black", "flake8", "isort", "pre-commit", "pyproject-flake8"]
 doc = ["myst-parser", "sphinx", "sphinx-book-theme"]
 test = ["coverage", "pytest", "pytest-cov"]
 
@@ -969,14 +969,14 @@ test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.3.1)", "pytest-
 
 [[package]]
 name = "pre-commit"
-version = "3.2.2"
+version = "3.3.1"
 description = "A framework for managing and maintaining multi-language pre-commit hooks."
 category = "dev"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pre_commit-3.2.2-py2.py3-none-any.whl", hash = "sha256:0b4210aea813fe81144e87c5a291f09ea66f199f367fa1df41b55e1d26e1e2b4"},
-    {file = "pre_commit-3.2.2.tar.gz", hash = "sha256:5b808fcbda4afbccf6d6633a56663fed35b6c2bc08096fd3d47ce197ac351d9d"},
+    {file = "pre_commit-3.3.1-py2.py3-none-any.whl", hash = "sha256:218e9e3f7f7f3271ebc355a15598a4d3893ad9fc7b57fe446db75644543323b9"},
+    {file = "pre_commit-3.3.1.tar.gz", hash = "sha256:733f78c9a056cdd169baa6cd4272d51ecfda95346ef8a89bf93712706021b907"},
 ]
 
 [package.dependencies]
@@ -1150,14 +1150,14 @@ files = [
 
 [[package]]
 name = "textual"
-version = "0.22.3"
+version = "0.23.0"
 description = "Modern Text User Interface framework"
 category = "main"
 optional = false
 python-versions = ">=3.7,<4.0"
 files = [
-    {file = "textual-0.22.3-py3-none-any.whl", hash = "sha256:1ef6457b9d8b727a67d2344bf2d0b530dce1afab55e1bf4e964e430929301baa"},
-    {file = "textual-0.22.3.tar.gz", hash = "sha256:a68172f7797e9f269270491e039f1e48096530dff64dbfe893e8477f2d4e200c"},
+    {file = "textual-0.23.0-py3-none-any.whl", hash = "sha256:9eb1284ae312801b12b19668bf84faa2ae226a2ab6269e5f84edff851f2ad371"},
+    {file = "textual-0.23.0.tar.gz", hash = "sha256:f3e08d7afaf6c8562d2d5d6230fa891b515ebf9813cda4ea1807a639032edbd4"},
 ]
 
 [package.dependencies]
@@ -1210,14 +1210,14 @@ files = [
 
 [[package]]
 name = "uc-micro-py"
-version = "1.0.1"
+version = "1.0.2"
 description = "Micro subset of unicode data files for linkify-it-py projects."
 category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 files = [
-    {file = "uc-micro-py-1.0.1.tar.gz", hash = "sha256:b7cdf4ea79433043ddfe2c82210208f26f7962c0cfbe3bacb05ee879a7fdb596"},
-    {file = "uc_micro_py-1.0.1-py3-none-any.whl", hash = "sha256:316cfb8b6862a0f1d03540f0ae6e7b033ff1fa0ddbe60c12cbe0d4cec846a69f"},
+    {file = "uc-micro-py-1.0.2.tar.gz", hash = "sha256:30ae2ac9c49f39ac6dce743bd187fcd2b574b16ca095fa74cd9396795c954c54"},
+    {file = "uc_micro_py-1.0.2-py3-none-any.whl", hash = "sha256:8c9110c309db9d9e87302e2f4ad2c3152770930d88ab385cd544e7a7e75f3de0"},
 ]
 
 [package.extras]
@@ -1448,4 +1448,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "cb8d0e669eef1ee7e64d4f8549a7488b7c485ebc913dac28d4e10695b2708060"
+content-hash = "efcb264d936ddfae97fee65988e4ae4f0d242ce19a7c6dce04ce7a1f8edf6395"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,14 +28,14 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
-textual = {version = "^0.22.2"}
+textual = {version = "^0.23.0"}
 typing-extensions = "^4.5.0"
 httpx = "^0.23.3"
 xdg = "^6.0.0"
 
 
 [tool.poetry.group.dev.dependencies]
-textual = {extras = ["dev"], version = "^0.22.2"}
+textual = {extras = ["dev"], version = "^0.23.0"}
 mypy = "^1.1.1"
 pylint = "^2.17.1"
 pre-commit = "^3.2.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,14 +28,14 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
-textual = {version = "^0.23.0"}
+textual = {version = "^0.24.0"}
 typing-extensions = "^4.5.0"
 httpx = "^0.23.3"
 xdg = "^6.0.0"
 
 
 [tool.poetry.group.dev.dependencies]
-textual = {extras = ["dev"], version = "^0.23.0"}
+textual = {extras = ["dev"], version = "^0.24.0"}
 mypy = "^1.1.1"
 pylint = "^2.17.1"
 pre-commit = "^3.2.1"


### PR DESCRIPTION
This PR includes changes to update Frogmouth to work on top of Textual v0.23.0. This includes:

- Updating the project file to specify v0.23.0 as the minimum required Textual.
- Change how the local file browser changes its root directory (no more `remove` and `mount`, instead setting `path`).

---
*NOTE*: Holding off merging until https://github.com/Textualize/textual/pull/2473 is released.