### PR TITLE
Add a `changelog` command

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,12 @@
 # Frogmouth ChangeLog
 
+## Unreleased
+
+### Added
+
+- Added a `changelog` command -- loads the Frogmouth ChangeLog from the
+  repository for viewing.
+
 ## [0.4.0] - 2023-05-03
 
 ### Added

--- a/frogmouth/dialogs/help_dialog.py
+++ b/frogmouth/dialogs/help_dialog.py
@@ -55,6 +55,7 @@ Press `/` or click the address bar, then enter any of the following commands:
 | `about` | `a` | | Show details about the application |
 | `bookmarks` | `b`, `bm` | | Show the bookmarks list |
 | `bitbucket` | `bb` | `<repo-info>` | View a file on BitBucket (see below) |
+| `changelog` | `cl` | | View the Frogmouth ChangeLog |
 | `chdir` | `cd` | `<dir>` | Switch the local file browser to a new directory |
 | `contents` | `c`, `toc` | | Show the table of contents for the document |
 | `discord` | | | Visit the Textualize Discord server |

--- a/frogmouth/widgets/omnibox.py
+++ b/frogmouth/widgets/omnibox.py
@@ -13,7 +13,7 @@ from textual.reactive import var
 from textual.widgets import Input
 
 from ..utility import is_likely_url
-from ..utility.advertising import DISCORD
+from ..utility.advertising import DISCORD, ORGANISATION_NAME, PACKAGE_NAME
 
 
 class Omnibox(Input):
@@ -48,6 +48,7 @@ class Omnibox(Input):
         "bb": "bitbucket",
         "c": "contents",
         "cd": "chdir",
+        "cl": "changelog",
         "gh": "github",
         "gl": "gitlab",
         "h": "history",
@@ -334,6 +335,10 @@ class Omnibox(Input):
     def command_discord(self, _: str) -> None:
         """The command to visit the Textualize discord server."""
         open_url(DISCORD)
+
+    def command_changelog(self, _: str) -> None:
+        """The command to show the application's own ChangeLog"""
+        self.command_github(f"{ORGANISATION_NAME}/{PACKAGE_NAME} ChangeLog.md")
 
     def command_obsidian(self, vault: str) -> None:
         """The command to visit an obsidian vault, if one can be seen.


### PR DESCRIPTION
A command to quickly load the latest Frogmouth ChangeLog from the repo and display it in the viewer.