### PR TITLE
Add Codeberg as a recognised forge

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,11 @@
 # Frogmouth ChangeLog
 
+## Unreleased
+
+### Added
+
+- Added Codeberg as a recognised forge for the "forge quick view".
+
 ## [0.5.0] - 2023-05-08
 
 ### Changed

--- a/frogmouth/dialogs/help_dialog.py
+++ b/frogmouth/dialogs/help_dialog.py
@@ -55,6 +55,7 @@ Press `/` or click the address bar, then enter any of the following commands:
 | `about` | `a` | | Show details about the application |
 | `bookmarks` | `b`, `bm` | | Show the bookmarks list |
 | `bitbucket` | `bb` | `<repo-info>` | View a file on BitBucket (see below) |
+| `codeberg` | `cb` | `<repo-info>` | View a file on Codceberg (see below) |
 | `changelog` | `cl` | | View the Frogmouth ChangeLog |
 | `chdir` | `cd` | `<dir>` | Switch the local file browser to a new directory |
 | `contents` | `c`, `toc` | | Show the table of contents for the document |

--- a/frogmouth/screens/main.py
+++ b/frogmouth/screens/main.py
@@ -20,6 +20,7 @@ from ..data import load_config, load_history, save_config, save_history
 from ..dialogs import ErrorDialog, HelpDialog, InformationDialog, InputDialog
 from ..utility import (
     build_raw_bitbucket_url,
+    build_raw_codeberg_url,
     build_raw_github_url,
     build_raw_gitlab_url,
     is_likely_url,
@@ -274,6 +275,14 @@ class Main(Screen[None]):  # pylint:disable=too-many-public-methods
             event: The BitBucket shortcut command event to handle.
         """
         await self._from_forge("BitBucket", event, build_raw_bitbucket_url)
+
+    async def on_omnibox_codeberg_command(self, event: Omnibox.CodebergCommand) -> None:
+        """Handle a Codeberg shortcut command.
+
+        Args:
+            event: The Codeberg shortcut command event to handle.
+        """
+        await self._from_forge("Codeberg", event, build_raw_codeberg_url)
 
     def on_omnibox_about_command(self) -> None:
         """Handle being asked to show the about dialog."""

--- a/frogmouth/utility/__init__.py
+++ b/frogmouth/utility/__init__.py
@@ -1,12 +1,18 @@
 """General utility and support code."""
 
-from .forge import build_raw_bitbucket_url, build_raw_github_url, build_raw_gitlab_url
+from .forge import (
+    build_raw_bitbucket_url,
+    build_raw_codeberg_url,
+    build_raw_github_url,
+    build_raw_gitlab_url,
+)
 from .type_tests import is_likely_url, maybe_markdown
 
 __all__ = [
+    "build_raw_bitbucket_url",
+    "build_raw_codeberg_url",
     "build_raw_github_url",
     "build_raw_gitlab_url",
-    "build_raw_bitbucket_url",
-    "maybe_markdown",
     "is_likely_url",
+    "maybe_markdown",
 ]

--- a/frogmouth/utility/forge.py
+++ b/frogmouth/utility/forge.py
@@ -143,3 +143,34 @@ async def build_raw_bitbucket_url(
         branch,
         desired_file,
     )
+
+
+async def build_raw_codeberg_url(
+    owner: str,
+    repository: str,
+    branch: str | None = None,
+    desired_file: str | None = None,
+) -> URL | None:
+    """Attempt to get the Codeberg raw URL for the given file.
+
+    Args:
+        owner: The owner of the repository to look in.
+        repository: The repository to look in.
+        branch: The optional branch to look in.
+        desired_file: Optional name of the file to go looking for.
+
+    Returns:
+        The URL for the file, or `None` if none could be guessed.
+
+    If the branch isn't supplied then `main` and `master` will be tested.
+
+    If the target file isn't supplied it's assumed that `README.md` is the
+    target.
+    """
+    return await build_raw_forge_url(
+        "https://codeberg.org/{owner}/{repository}/raw//branch/{branch}/{file}",
+        owner,
+        repository,
+        branch,
+        desired_file,
+    )

--- a/frogmouth/widgets/omnibox.py
+++ b/frogmouth/widgets/omnibox.py
@@ -47,6 +47,7 @@ class Omnibox(Input):
         "bm": "bookmarks",
         "bb": "bitbucket",
         "c": "contents",
+        "cb": "codeberg",
         "cd": "chdir",
         "cl": "changelog",
         "gh": "github",
@@ -331,6 +332,17 @@ class Omnibox(Input):
             tail: The tail of the command.
         """
         self._forge_quick_look(self.BitBucketCommand, tail)
+
+    class CodebergCommand(ForgeCommand):
+        """The Codeberg quick load command."""
+
+    def command_codeberg(self, tail: str) -> None:
+        """The Codeberg command.
+
+        Args:
+            tail: The tail of the command.
+        """
+        self._forge_quick_look(self.CodebergCommand, tail)
 
     def command_discord(self, _: str) -> None:
         """The command to visit the Textualize discord server."""


### PR DESCRIPTION
Adds [Codeberg](https://codeberg.org/) as a recognised forge for the "quick forge load" facility. In doing so adds a `codeberg` with an alias of `cb`.