### PR TITLE
Capture `RequestError` in `build_raw_forge_url`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,12 @@
 # Frogmouth ChangeLog
 
+## [0.7.0] - Unreleased
+
+### Fixed
+
+- Added some extra error capture when attempting to build a forge URL while
+  inferring the main branch name.
+
 ## [0.6.0] - 2023-05-24
 
 ### Added

--- a/frogmouth/utility/forge.py
+++ b/frogmouth/utility/forge.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from httpx import URL, AsyncClient, HTTPStatusError
+from httpx import URL, AsyncClient, HTTPStatusError, RequestError
 
 from .advertising import USER_AGENT
 
@@ -39,11 +39,16 @@ async def build_raw_forge_url(
                 branch=test_branch,
                 file=desired_file,
             )
-            response = await client.head(
-                url,
-                follow_redirects=True,
-                headers={"user-agent": USER_AGENT},
-            )
+            try:
+                response = await client.head(
+                    url,
+                    follow_redirects=True,
+                    headers={"user-agent": USER_AGENT},
+                )
+            except RequestError:
+                # We've failed to even make the request, there's no point in
+                # trying to build anything here.
+                return None
             try:
                 response.raise_for_status()
                 return URL(url)


### PR DESCRIPTION
This pretty much turns it into a no-op. In this case that feels fair; there's a problem with the connection and we're trying to make guesses on behalf of the user; this is our guess: there's no forge to speak to right now and so no guess to be made.