### PR TITLE
Handle document-relative links to non-markdown files when CWD isn't the document's location

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,9 @@
 
 - Added some extra error capture when attempting to build a forge URL while
   inferring the main branch name.
+- Fixed following local file links where the file is document-relative and
+  you're visiting with a CWD other than the document's.
+  [#52](https://github.com/Textualize/frogmouth/issues/52)
 
 ## [0.6.0] - 2023-05-24
 

--- a/frogmouth/screens/main.py
+++ b/frogmouth/screens/main.py
@@ -407,8 +407,8 @@ class Main(Screen[None]):  # pylint:disable=too-many-public-methods
             .exists()
         ):
             # It looks like a local file, and tested relative to the
-            # document we found it in it exists, so let's assume that's what
-            # we're supposed to handle.
+            # document we found it exists in the local filesystem, so let's
+            # assume that's what we're supposed to handle.
             self.visit(local_file)
         else:
             # Yeah, not sure *what* this link is. Rather than silently fail,

--- a/frogmouth/screens/main.py
+++ b/frogmouth/screens/main.py
@@ -127,7 +127,7 @@ class Main(Screen[None]):  # pylint:disable=too-many-public-methods
             # resource seems to exist...
             if location.exists():
                 # ...ask the OS to open it.
-                open_url(str(location))
+                open_url(f"file:///{location.absolute()}")
             else:
                 # It's a Path but it doesn't exist, there's not much else we
                 # can do with it.


### PR DESCRIPTION
See #52.