### PR TITLE
Add a reload command

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,11 @@
 
 ## [0.7.0] - Unreleased
 
+### Added
+
+- Added support for using <kbd>Ctrl</kbd>+<kbd>r</kbd> to reload the current
+  document.
+
 ### Fixed
 
 - Added some extra error capture when attempting to build a forge URL while

--- a/frogmouth/dialogs/help_dialog.py
+++ b/frogmouth/dialogs/help_dialog.py
@@ -41,6 +41,7 @@ Welcome to {APPLICATION_TITLE} Help!
 | Key | Command |
 | -- | -- |
 | `Ctrl+d` | Add the current document to the bookmarks |
+| `Ctrl+r` | Reload the current document |
 | `Ctrl+q` | Quit the application |
 | `F1` | This help |
 | `F2` | Details about {APPLICATION_TITLE} |

--- a/frogmouth/screens/main.py
+++ b/frogmouth/screens/main.py
@@ -78,6 +78,7 @@ class Main(Screen[None]):  # pylint:disable=too-many-public-methods
         Binding("ctrl+l", "local_files", "", show=False),
         Binding("ctrl+left", "backward", "", show=False),
         Binding("ctrl+right", "forward", "", show=False),
+        Binding("ctrl+r", "reload", "", show=False),
         Binding("ctrl+t", "table_of_contents", "", show=False),
         Binding("ctrl+y", "history", "", show=False),
         Binding("escape", "escape", "", show=False),
@@ -541,3 +542,7 @@ class Main(Screen[None]):  # pylint:disable=too-many-public-methods
         save_config(config)
         # pylint:disable=attribute-defined-outside-init
         self.app.dark = not config.light_mode
+
+    def action_reload(self) -> None:
+        """Reload the current document."""
+        self.query_one(Viewer).reload()

--- a/frogmouth/widgets/viewer.py
+++ b/frogmouth/widgets/viewer.py
@@ -264,6 +264,11 @@ class Viewer(VerticalScroll, can_focus=True, can_focus_children=True):
         else:
             raise ValueError("Unknown location type passed to the Markdown viewer")
 
+    def reload(self) -> None:
+        """Reload the current location."""
+        if self.location is not None:
+            self.visit(self.location, False)
+
     def show(self, content: str) -> None:
         """Show some direct text in the viewer.
 


### PR DESCRIPTION
Consider this a "hits most use cases" initial take on #44; I think this is needed anyway. Reloading based on external input should follow later, but I think those things make more sense when I can make a best-efforts attempt at reloading and ending up at the same position (which would help make things feel more like a live-edit viewer).

Anyway, that's a different request/PR. This is about a simple refresh.