### PR TITLE
Respect REQUESTS_CA_BUNDLE as a provider of cert bundle at runtime.

### DIFF
--- a/frogmouth/utility/forge.py
+++ b/frogmouth/utility/forge.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from httpx import URL, AsyncClient, HTTPStatusError, RequestError
 
 from .advertising import USER_AGENT
@@ -31,7 +32,9 @@ async def build_raw_forge_url(
     target.
     """
     desired_file = desired_file or "README.md"
-    async with AsyncClient() as client:
+    verify = os.getenv("REQUESTS_CA_BUNDLE", True)
+
+    async with AsyncClient(verify=verify) as client:
         for test_branch in (branch,) if branch else ("main", "master"):
             url = url_format.format(
                 owner=owner,


### PR DESCRIPTION
Fetching contents from a site with a custom SSL cert setup causes the following error:
```
SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer 
certificate (_ssl.c:1129)
```

Ideally, we'd like to respect custom cert bundles at runtime, and `requests` takes a [`REQUESTS_CA_BUNDLE` approach](https://stackoverflow.com/a/42982144/14045826) for it. We could use the same here.

In the new version, the usage would look like this:
```sh
REQUESTS_CA_BUNDLE=/path/to/bundle frogmouth https://site-with-custom-ssl-setup/-/blob/main/README.md
```

