### PR TITLE
Add support for short URLs

### DIFF
--- a/frogmouth/utility/type_tests.py
+++ b/frogmouth/utility/type_tests.py
@@ -45,13 +45,10 @@ async def _(resource: URL) -> bool:
                 follow_redirects=True,
                 headers={"user-agent": USER_AGENT},
             )
-        except RequestError:
+            response.raise_for_status()
+        except (RequestError, HTTPStatusError) as error:
             # We've failed to even make the request, there's no point in
             # trying to build anything here.
-            return False
-        try:
-            response.raise_for_status()
-        except HTTPStatusError:
             return False
     return maybe_markdown(response.url.path)
 


### PR DESCRIPTION
Ex: Twitter short URL
`py -m frogmouth https://t.co/5AU9qe7pQ1`

![image](https://github.com/Textualize/frogmouth/assets/44526468/fb14b3fd-ab07-4336-9f32-92cb7455a5a2)
