### PR TITLE
Disable the command palette

### DIFF
--- a/frogmouth/app/app.py
+++ b/frogmouth/app/app.py
@@ -18,6 +18,8 @@ class MarkdownViewer(App[None]):
     TITLE = APPLICATION_TITLE
     """The main title for the application."""
 
+    ENABLE_COMMAND_PALETTE = False
+
     def __init__(self, cli_args: Namespace) -> None:
         """Initialise the application.
 


### PR DESCRIPTION
It's not used for anything useful in Frogmouth right now, and will also bypass the dark/light mode sticky toggle too. This can be fixed (the code to make that sticky pre-dates the command palette by quite some way) but given there's no other use for the command palette at the moment I'll just disable it.

It can come back when actual commands get implemented.