### PR TITLE
Support jumping to a document heading

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,8 @@
 
 - Front matter is now ignored when viewing a file.
   [#15](https://github.com/Textualize/frogmouth/issues/15)
+- Added support for jumping to an internal anchor.
+  [#91](https://github.com/Textualize/frogmouth/issues/91)
 
 ## [0.9.2] - 2023-11-28
 

--- a/frogmouth/screens/main.py
+++ b/frogmouth/screens/main.py
@@ -411,6 +411,12 @@ class Main(Screen[None]):  # pylint:disable=too-many-public-methods
             # document we found it exists in the local filesystem, so let's
             # assume that's what we're supposed to handle.
             self.visit(local_file)
+        elif event.href.startswith("#") and event.markdown.goto_anchor(event.href[1:]):
+            # The href started with a # and the remains of it were satisfied
+            # as an anchor within the document of the Markdown. We should
+            # have scrolled to about the right spot in the document so we
+            # don't need to do anything else.
+            pass
         else:
             # Yeah, not sure *what* this link is. Rather than silently fail,
             # let's let the user know we don't know how to process this.


### PR DESCRIPTION
*[Ignore the branch name; managed to work on the wrong branch]*

Handle jumping within a document, when linking to header-related anchors.

Implements #91.
