### PR TITLE
Revert the Textual version to 0.53.1

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1007,13 +1007,13 @@ files = [
 
 [[package]]
 name = "textual"
-version = "0.54.0"
+version = "0.53.1"
 description = "Modern Text User Interface framework"
 optional = false
-python-versions = "<4.0,>=3.8"
+python-versions = ">=3.8,<4.0"
 files = [
-    {file = "textual-0.54.0-py3-none-any.whl", hash = "sha256:94aacf28dece20a44f0b94b087e17ff4ac961acd92e12e648f060fe2555b3adc"},
-    {file = "textual-0.54.0.tar.gz", hash = "sha256:0cfd134dde5ae49d64dd73bb32a2fb5a86d878d9caeacecaa1d640082f31124e"},
+    {file = "textual-0.53.1-py3-none-any.whl", hash = "sha256:32201aa9d334ed064d5e670f15fe3d7f19c736ca54cecb054a5b995691104434"},
+    {file = "textual-0.53.1.tar.gz", hash = "sha256:23ba673be7974819ded35ea88d28df7117987e53d58f15b2cc890ac2ecf56401"},
 ]
 
 [package.dependencies]
@@ -1305,4 +1305,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "9728e726fcd344097cab3122ee4faea00f36bfbd0695f9a936a8ea3716e5918e"
+content-hash = "7759c0106c0800da8b1b56d1a93c234143faad5618d6216d8e5308cfc23c67d3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
-textual = ">=0.54.0"
+textual = "==0.53.1"
 typing-extensions = "^4.5.0"
 httpx = "^0.24.1"
 xdg = "^6.0.0"


### PR DESCRIPTION
See #98 and https://github.com/Textualize/textual/issues/4360 for more context. For the moment this commit will undo the change made in respect to the request made in #94, but we'll have to remember to unpin again as soon as the Textual issue is resolved.