### PR TITLE
Ability to view markdown without clicking on them in file explorer.

### DIFF
--- a/frogmouth/screens/main.py
+++ b/frogmouth/screens/main.py
@@ -111,7 +111,7 @@ class Main(Screen[None]):  # pylint:disable=too-many-public-methods
             yield Viewer(classes="focusable")
         yield Footer()
 
-    def visit(self, location: Path | URL, remember: bool = True) -> None:
+    def visit(self, location: Path | URL, remember: bool = True, focus:bool = True) -> None:
         """Visit the given location.
 
         Args:
@@ -122,7 +122,7 @@ class Main(Screen[None]):  # pylint:disable=too-many-public-methods
         # locally in the filesystem or out on the web...
         if maybe_markdown(location):
             # ...attempt to visit it in the viewer.
-            self.query_one(Viewer).visit(location, remember)
+            self.query_one(Viewer).visit(location, remember, focus)
         elif isinstance(location, Path):
             # So, it's not Markdown, but it *is* a Path of some sort. If the
             # resource seems to exist...
@@ -303,7 +303,7 @@ class Main(Screen[None]):  # pylint:disable=too-many-public-methods
         Args:
             event: The local file visit request event.
         """
-        self.visit(event.location)
+        self.visit(event.location , focus=event.focus_viewer)
 
     def on_history_goto(self, event: History.Goto) -> None:
         """Handle a request to go to a location from history.

--- a/frogmouth/widgets/viewer.py
+++ b/frogmouth/widgets/viewer.py
@@ -254,7 +254,7 @@ class Viewer(VerticalScroll, can_focus=True, can_focus_children=True):
             # to the user. Let's be nice...
             open_url(str(location))
 
-    def visit(self, location: Path | URL, remember: bool = True) -> None:
+    def visit(self, location: Path | URL, remember: bool = True, focus:bool=True) -> None:
         """Visit a location.
 
         Args:
@@ -263,6 +263,7 @@ class Viewer(VerticalScroll, can_focus=True, can_focus_children=True):
         """
         # Based on the type of the location, load up the content.
         if isinstance(location, Path):
+            self.can_focus = focus
             self._local_load(location.expanduser().resolve(), remember)
         elif isinstance(location, URL):
             self._remote_load(location, remember)


### PR DESCRIPTION
Hi there

This is the change for this feature [Add an auto-view mode ](https://github.com/Textualize/frogmouth/issues/104).
Though its half the feature whats propose.

Thanks :) 

#### Feature Change:

- Ability to view markdown without clicking on them directory tree.
- Ability to focus the viewer with enter key.

#### Modified

- screens/main.py
- widgets/viewer.py
- widgets/navigation_panes/local_files.py
